### PR TITLE
Updates GPG setup

### DIFF
--- a/hidden/.gitconfig
+++ b/hidden/.gitconfig
@@ -3,7 +3,7 @@
 # Please adapt and uncomment the following lines:
 	name = Dylan Gattey
 	email = dgattey@linkedin.com
-	signingKey = 5FFB96A3FC14D1059ABDA03D5EB68D3DECED52CD
+	signingKey = 10B62A63CAA064C41091471B86769BCAF264E198
 [core]
 	excludesfile = /Users/dgattey/.gitignore_global
     attributesfile = ~/.gitattributes

--- a/install.sh
+++ b/install.sh
@@ -259,7 +259,6 @@ install_packages() {
     install_package "command -v go" "go"
     install_package "brew ls --version chisel" "chisel"
     install_package "brew ls --versions git-credential-manager" "git-credential-manager"
-    install_package "command -v gpg" "gnupg"
 }
 
 # Installs a single package by checking a command and installing it if missing


### PR DESCRIPTION
Should download GPGSuite for Mac. It makes it way simpler!! This updates with my new key and also removes the brew-installed program.